### PR TITLE
Fix misprint in org.apache.spark.ml.odkl.texts.NGramExtractor

### DIFF
--- a/src/main/scala/org/apache/spark/ml/odkl/texts/NGramExtractor.scala
+++ b/src/main/scala/org/apache/spark/ml/odkl/texts/NGramExtractor.scala
@@ -53,7 +53,7 @@ class NGramExtractor(override val uid: String)
 
   @DeveloperApi
   override def transformSchema(schema: StructType): StructType = {
-    if ($(inputCol) == $(outputCol)) {
+    if ($(inputCol) != $(outputCol)) {
       schema.add($(outputCol), new ArrayType(StringType, true))
     } else {
       schema


### PR DESCRIPTION
"==" change to "!="
I think it's correctly.